### PR TITLE
adjust sizes of mobile header on lower resolutions

### DIFF
--- a/src/styles/general.less
+++ b/src/styles/general.less
@@ -678,6 +678,13 @@ input::placeholder {
       .summit-text--no-logo {
         margin-top: 0px;
       }
+      a {
+        width: 200px;
+        img {
+          width: 100%;
+          height: auto;
+        }
+      }
     }    
     &--no-logo {
       margin-top: 0px; 


### PR DESCRIPTION
* Adjust header with new buttons for lower resolutions

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=2588557

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>