### PR TITLE
Disable edits for invite only events. Auto assign

### DIFF
--- a/src/actions/order-actions.js
+++ b/src/actions/order-actions.js
@@ -140,6 +140,14 @@ export const createReservation = (owner_email, owner_first_name, owner_last_name
             t.attendee_company = owner_company;
         }
 
+        // if the summit is only invite, assign the ticket to the order owner
+        if(purchaseSummit.invite_only_registration) {
+            t.attendee_email = owner_email;
+            t.attendee_first_name = owner_first_name;
+            t.attendee_last_name = owner_last_name;
+            t.attendee_company = owner_company;
+        }
+
         return t;
     });
 

--- a/src/components/basic-info-form.js
+++ b/src/components/basic-info-form.js
@@ -61,7 +61,7 @@ class BasicInfoForm extends React.Component {
 
 
     render() {
-        let {order, onChange, member} = this.props;
+        let {order, onChange, member, invitation} = this.props;
 
         return (
             <div className="basic-info">
@@ -89,9 +89,10 @@ class BasicInfoForm extends React.Component {
                     <div className="col-md-6">
                         <Input
                             id="first_name"
-                            className="form-control"
+                            className={`form-control ${!!invitation ? 'disabled': ''}`}
                             error={this.hasErrors('first_name')}
                             onChange={onChange}
+                            disabled={!!invitation && !invitation?.first_name}
                             value={order.first_name}
                         />
                     </div>
@@ -103,9 +104,10 @@ class BasicInfoForm extends React.Component {
                     <div className="col-md-6">
                         <Input
                             id="last_name"
-                            className="form-control"
+                            className={`form-control ${!!invitation ? 'disabled': ''}`}
                             error={this.hasErrors('last_name')}
                             onChange={onChange}
+                            disabled={!!invitation && !invitation?.last_name}
                             value={order.last_name}
                         />
                     </div>
@@ -117,9 +119,10 @@ class BasicInfoForm extends React.Component {
                     <div className="col-md-6">
                         <Input
                             id="email"
-                            className="form-control"
+                            className={`form-control ${!!invitation ? 'disabled': ''}`}
                             error={this.hasErrors('email')}
                             onChange={onChange}
+                            disabled={!!invitation && !invitation?.email}
                             value={order.email}
                         />
                     </div>

--- a/src/pages/step-two-page.js
+++ b/src/pages/step-two-page.js
@@ -209,7 +209,7 @@ class StepTwoPage extends React.Component {
       }
 
     render(){
-        let {summit, order, errors, member} = this.props;
+        let {summit, order, invitation, errors, member} = this.props;
         let {dirty} = this.state;
         const disclaimer = getMarketingValue('registration_in_person_disclaimer');
         let ticketsTypesToSell = this.handleTicketToSale();
@@ -220,8 +220,13 @@ class StepTwoPage extends React.Component {
                 <StepRow step={this.step} />
                 <div className="row">
                     <div className="col-md-8">
-                        <BasicInfoForm order={order} errors={dirty? errors : {}} onChange={this.handleChange} member={member}/>
-                        {ticketsTypesToSell.map((t,i) => (
+                        <BasicInfoForm 
+                            order={order} 
+                            invitation={invitation?.summit_id === summit.id ? invitation : null}
+                            errors={dirty? errors : {}} 
+                            onChange={this.handleChange} 
+                            member={member}/>
+                        {invitation?.summit_id !== summit.id && ticketsTypesToSell.map((t,i) => (
                             <TicketInfoForm
                                 now={this.props.getNow()}
                                 key={`tixinfo_${t.ticket_type_id}_${i}`}

--- a/src/styles/step-two-page.less
+++ b/src/styles/step-two-page.less
@@ -24,6 +24,9 @@
       &::placeholder{
         color: #A4C7E6;
       }
+      &.disabled {
+        background-color: lightgray;
+      }
     }
     
     .ticket-number {


### PR DESCRIPTION
* Disable the fields with data from the profile (first name, last name and email)
* Hides the ticket assign and promo codes
* Auto assign tickets with the order owner data.

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=2746575

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>