### PR TITLE
Removing 'Do this later' button from extra qustions on purchase flow

### DIFF
--- a/src/pages/step-extra-questions-page.js
+++ b/src/pages/step-extra-questions-page.js
@@ -224,11 +224,6 @@ class StepExtraQuestionsPage extends React.Component {
                             onClick={this.onTicketsSave}>
                             {T.translate("ticket_popup.save_changes")}
                         </button>
-                        <span className="or">OR</span>
-                        <a className="back-btn" href="#" onClick={this.onSkip}>
-                            {T.translate("ticket_popup.do_it_later")}
-                            <i className="fa fa-chevron-right" aria-hidden="true"></i>
-                        </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
* Removing the 'Do this later' button from the purchase flow

ref: https://tipit.avaza.com/project/view#!tab=task-pane&groupby=MyTaskProject&view=vertical&task=2779651&fileview=grid

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>