### PR TITLE
Removing 'optional' texts from purchase flow

### DIFF
--- a/src/components/step-row.js
+++ b/src/components/step-row.js
@@ -24,7 +24,7 @@ class StepRow extends React.Component {
         return (
             <div className="row step-row">
                 <div className="col-md-6">
-                {optional ? "Optional": ""} Step {step} of {totalSteps} 
+                Step {step} of {totalSteps} 
                 </div>
                 {((step === 2 || step === 3) && !optional)?
                 <div className="col-md-6">                    

--- a/src/pages/step-extra-questions-page.js
+++ b/src/pages/step-extra-questions-page.js
@@ -176,7 +176,6 @@ class StepExtraQuestionsPage extends React.Component {
                     <StepRow step={this.step} optional={true} />
                     <div className="col-md-8 order-result">
 
-                        {T.translate("ticket_popup.do_it_later_exp")}
                         {this.state.tickets.map((ticket, index) => {
                             let model = new TicketModel(ticket, summit, now);
                             let status = model.getStatus();


### PR DESCRIPTION
* removing 'optional' texts from the purchase flow.

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=2779651

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>