### PR TITLE
Setting null alt property for images on login popup

### DIFF
--- a/src/components/login/step-one/index.js
+++ b/src/components/login/step-one/index.js
@@ -70,7 +70,7 @@ const LoginStepOneComponent = ({
                 style={{ backgroundColor: o.button_color, color: o.font_color }}
                 onClick={() => login(o.provider_param)}
               >
-                <img src={o.provider_icon} className='icon' />
+                <img src={o.provider_icon} alt="" className='icon' />
                 {T.translate(o.provider_label_key)}
               </button>
               :
@@ -81,7 +81,7 @@ const LoginStepOneComponent = ({
                   style={{ backgroundColor: o.button_color }}
                   onClick={() => login(o.provider_param)}
                 >
-                  <img src={o.provider_icon} className='icon' />
+                  <img src={o.provider_icon} alt="" className='icon' />
                   {T.translate(o.provider_label_key)}
                 </button>
                 :


### PR DESCRIPTION
* Setting alt prop as null for providers logos on login to improve accessibility

ref: https://tipit.avaza.com/project/view#!tab=task-pane&groupby=MyTaskProject&view=vertical&task=2791822&fileview=grid

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>