### PR TITLE
Adding new summit prop to disable extra question edition

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "moment": "^2.22.0",
     "moment-timezone": "^0.5.27",
     "node-sass": "^4.14.1",
-    "openstack-uicore-foundation": "^3.0.49",
+    "openstack-uicore-foundation": "^3.0.51",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "qrcode.react": "^1.0.0",
     "react": "^16.9.0",

--- a/src/components/questions-answer-input.js
+++ b/src/components/questions-answer-input.js
@@ -30,6 +30,7 @@ export default class QuestionAnswersInput extends React.Component {
 
         this.state = {
             answers: answers,
+            intialAnswers: answers
         };
 
         this.handleChange = this.handleChange.bind(this);
@@ -75,13 +76,16 @@ export default class QuestionAnswersInput extends React.Component {
 
     getInput(question, answerValue) {        
         let questionValues = question.values;
-        let {ticket} = this.props;
+        let {ticket, allowEdit} = this.props;
+        let {intialAnswers} = this.state;
 
         let htmlLabel = question.label;
         if (question.mandatory) {
             //Assuming that labels generated as html are wrapped in <p> bc the react-rte component generates them that way (defaultBlockTag: 'p')
             htmlLabel = htmlLabel?.endsWith('</p>') ? htmlLabel.replace(/<\/p>$/g, " *</p>") : `${htmlLabel} *`;
         }
+
+        const answered = !!intialAnswers.find(ans => ans.question_id === question.id)?.answer;        
 
         switch(question.type) {
             case 'Text':
@@ -97,6 +101,7 @@ export default class QuestionAnswersInput extends React.Component {
                                   value={answerValue}
                                   onChange={this.handleChange}
                                   placeholder={question.placeholder}
+                                  disabled={!allowEdit && answered}
                                   className="form-control"
                               />
                           </div>                        
@@ -111,6 +116,7 @@ export default class QuestionAnswersInput extends React.Component {
                                   value={answerValue}
                                   onChange={this.handleChange}
                                   placeholder={question.placeholder}
+                                  disabled={!allowEdit && answered}
                                   className="form-control"
                               />
                           </div>
@@ -130,6 +136,7 @@ export default class QuestionAnswersInput extends React.Component {
                                 value={answerValue}
                                 onChange={this.handleChange}
                                 placeholder={question.placeholder}
+                                disabled={!allowEdit && answered}
                                 className="form-control"                                
                                 rows="4"
                             />
@@ -145,6 +152,7 @@ export default class QuestionAnswersInput extends React.Component {
                                 value={answerValue}
                                 onChange={this.handleChange}
                                 placeholder={question.placeholder}
+                                disabled={!allowEdit && answered}
                                 className="form-control"                                
                                 rows="4"
                             />
@@ -156,8 +164,7 @@ export default class QuestionAnswersInput extends React.Component {
                   return (
                     <div className="form-check abc-checkbox">
                         <input type="checkbox" id={`${ticket.id}_${question.id}`} checked={(answerValue === "true")}
-                               onChange={this.handleChange} className="form-check-input" />
-
+                            disabled={!allowEdit && answered} onChange={this.handleChange} className="form-check-input" />
                         <label className="form-check-label" htmlFor={`${ticket.id}_${question.id}`} >
                             <RawHTML>{htmlLabel}</RawHTML>
                         </label>
@@ -178,6 +185,7 @@ export default class QuestionAnswersInput extends React.Component {
                                 id={question.id}
                                 value={value}
                                 options={questionValues}
+                                disabled={!allowEdit && answered}
                                 onChange={this.handleChange}
                             />
                           </div>                        
@@ -191,6 +199,7 @@ export default class QuestionAnswersInput extends React.Component {
                                 id={question.id}
                                 value={value}
                                 options={questionValues}
+                                disabled={!allowEdit && answered}
                                 onChange={this.handleChange}
                             />
                           </div>                        
@@ -213,6 +222,7 @@ export default class QuestionAnswersInput extends React.Component {
                                   value={answerValue}
                                   options={questionValues}
                                   onChange={this.handleChange}
+                                  disabled={!allowEdit && answered}
                               />
                           </div>                        
                       </div>
@@ -226,6 +236,7 @@ export default class QuestionAnswersInput extends React.Component {
                                 value={answerValue}
                                 options={questionValues}
                                 onChange={this.handleChange}
+                                disabled={!allowEdit && answered}
                             />
                         </div>                        
                     </div>
@@ -244,6 +255,7 @@ export default class QuestionAnswersInput extends React.Component {
                                   id={`${ticket.id}_${question.id}`}
                                   value={answerValue}
                                   options={questionValues}
+                                  disabled={!allowEdit && answered}
                                   onChange={this.handleChange}
                                   inline
                               />

--- a/src/components/questions-answer-input.js
+++ b/src/components/questions-answer-input.js
@@ -85,7 +85,8 @@ export default class QuestionAnswersInput extends React.Component {
             htmlLabel = htmlLabel?.endsWith('</p>') ? htmlLabel.replace(/<\/p>$/g, " *</p>") : `${htmlLabel} *`;
         }
 
-        const answered = !!intialAnswers.find(ans => ans.question_id === question.id)?.answer;        
+        const answered = question.type === 'CheckBox' && intialAnswers.find(ans => ans.question_id === question.id)?.answer === 'false' ? 
+                         false : intialAnswers.find(ans => ans.question_id === question.id)?.answer ? true: false;        
 
         switch(question.type) {
             case 'Text':

--- a/src/components/ticket-assign-form.js
+++ b/src/components/ticket-assign-form.js
@@ -82,13 +82,14 @@ class TicketAssignForm extends React.Component {
 
     render() {
 
-        let {guest, ownedTicket, owner, ticket, extraQuestions, status, summit, orderOwned, readOnly, now, shouldEditBasicInfo} = this.props;
+        let {guest, ownedTicket, owner, ticket, extraQuestions, status, summit, orderOwned, readOnly, now, shouldEditBasicInfo, fromTicketList} = this.props;
         let showCancel = true;
         if(!shouldEditBasicInfo) shouldEditBasicInfo = false;
         if(this.props.hasOwnProperty('showCancel'))
             showCancel = this.props.showCancel;
         let {extra_questions, input_email} = this.state;
-        ticket.disclaimer_accepted = ticket.disclaimer_accepted == null ? false : ticket.disclaimer_accepted
+        ticket.disclaimer_accepted = ticket.disclaimer_accepted == null ? false : ticket.disclaimer_accepted;
+        const allow_extra_questions_edit = fromTicketList !== true || ownedTicket && summit.allow_update_attendee_extra_questions;
         return (
             <div className="ticket-assign-form">
                 <div className="row popup-basic-info">
@@ -305,6 +306,7 @@ class TicketAssignForm extends React.Component {
                     </div>
                     <QuestionAnswersInput
                         id={`${ticket.id}_extra_questions`}
+                        allowEdit={allow_extra_questions_edit}
                         answers={ticket.extra_questions}
                         ticket={ticket}
                         questions={extraQuestions}

--- a/src/components/ticket-popup.js
+++ b/src/components/ticket-popup.js
@@ -384,6 +384,7 @@ class TicketPopup extends React.Component {
                             ticket={tempTicket} 
                             status={status.text} 
                             ownedTicket={fromTicketList || owner? owner.email === member.email : false }
+                            fromTicketList={fromTicketList}
                             orderOwned={orderOwned}
                             owner={owner}
                             extraQuestions={extraQuestions}

--- a/src/styles/ticket-assign-form.less
+++ b/src/styles/ticket-assign-form.less
@@ -34,6 +34,9 @@
       background-color: @lblue_color_1;
       border-color: @header_lblue_color;
       display: inline-flex;
+      &:disabled{
+        background-color: lightgray;        
+      }
     }
     .css-bg1rzq-control, .css-1szy77t-control {          
       background-color: @lblue_color_1;
@@ -45,6 +48,9 @@
     textarea {
       background-color: @lblue_color_1;
       border-color: @header_lblue_color;
+      &:disabled{
+        background-color: lightgray;        
+      }
     }
     &--textarea {
       align-items: flex-start;
@@ -85,6 +91,9 @@
       color: @font_blue_2 !important;
       &::placeholder {
         color: @input_hint_color !important;
+      }
+      &:disabled{
+        background-color: lightgray;        
       }
     }
     .abc-checkbox label{


### PR DESCRIPTION
* On registration uses the new summit prop `allow_update_attendee_extra_questions` to enable/disable the edit of extra questions on my tickets

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=2790751

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>