### PR TITLE
Catching invalid hash on reservation error

### DIFF
--- a/src/actions/order-actions.js
+++ b/src/actions/order-actions.js
@@ -279,7 +279,8 @@ export const payReservation = (token = null, stripe = null) => (dispatch, getSta
           .catch(e => {
               dispatch(stopLoading());
               if(e.err?.status === 412) {
-                  history.push(stepDefs[1])
+                  history.push(stepDefs[1]);
+                  dispatch(createAction(CLEAR_RESERVATION)({}));
               }
               return (e);
           });
@@ -328,7 +329,8 @@ export const payReservation = (token = null, stripe = null) => (dispatch, getSta
                     .catch(e => {
                         dispatch(stopLoading());
                         if(e.err?.status === 412) {
-                            history.push(stepDefs[1])
+                            history.push(stepDefs[1]);
+                            dispatch(createAction(CLEAR_RESERVATION)({}));
                         }
                         return (e);
                     });
@@ -457,6 +459,10 @@ export const updateOrderTickets = (tickets) => (dispatch, getState) => {
             }
         }).catch(e => {
             dispatch(stopLoading());
+            if(e.err?.status === 412) {
+                history.push(stepDefs[1]);
+                dispatch(createAction(CLEAR_RESERVATION)({}));
+            }
             return (e);
         });
 };

--- a/src/actions/order-actions.js
+++ b/src/actions/order-actions.js
@@ -278,6 +278,9 @@ export const payReservation = (token = null, stripe = null) => (dispatch, getSta
           })
           .catch(e => {
               dispatch(stopLoading());
+              if(e.err?.status === 412) {
+                  history.push(stepDefs[1])
+              }
               return (e);
           });
     } else {
@@ -324,6 +327,9 @@ export const payReservation = (token = null, stripe = null) => (dispatch, getSta
                     })
                     .catch(e => {
                         dispatch(stopLoading());
+                        if(e.err?.status === 412) {
+                            history.push(stepDefs[1])
+                        }
                         return (e);
                     });
                 // The payment has succeeded. Display a success message.


### PR DESCRIPTION
* Catching invalid hash error before order confirmation. Now it should reset the process to force a new hash for reservation

ref: https://tipit.avaza.com/project/view#!tab=task-pane&groupby=MyTaskDueDate&view=vertical&task=2813416&fileview=grid

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>